### PR TITLE
Bump version to 0.3.0 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ First, add the [Rust crate](https://crates.io/crates/rustler_elixir_fun) to your
 
 ```
 [dependencies]
-rustler_elixir_fun = "0.1.0"
+rustler_elixir_fun = "0.3.0"
 ```
 
 Secondly, add the [Elixir library](https://hex.pm/packages/rustler_elixir_fun) to your `mix.exs`:
 ```elixir
 def deps do
   [
-    {:rustler_elixir_fun, "~> 0.1.0"}
+    {:rustler_elixir_fun, "~> 0.3.0"}
   ]
 end
 ```


### PR DESCRIPTION
Little README.md nit, had troubles trying to use the 0.1.0 by following the README due to panics.